### PR TITLE
Fix refresh

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -295,6 +295,11 @@ export default function GamePage() {
               setTimeout(() => {
                 setFinalCaptureMessage(null);
               }, 3000);
+            } else if (payload.message){
+                if (payload.message.startsWith("Error updating game: Game with id") && payload.message.endsWith("does not exist"))
+                {
+                  console.log("Exiting empty game");
+                  router.push("/home")}
             } else {
               console.log(
                 "Unknown message from queue: " + JSON.stringify(payload),

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -36,6 +36,7 @@ interface MoveState {
 
 export default function GamePage() {
   const hasPublishedRef = useRef(false);
+  const [hydrated, setHydrated] = useState(false);
   const { id } = useParams();
   const [gameState, setGameState] = useState<GameSessionState>(
     initialGameState,
@@ -99,6 +100,10 @@ export default function GamePage() {
 
     return seatIndex;
   };
+
+  useEffect(() => {
+    setHydrated(true)
+  }, []);
 
   useEffect(() => {
     // ensure we actually have an array
@@ -487,6 +492,10 @@ export default function GamePage() {
       body: payload,
     });
   };
+
+  if(!hydrated) {
+    return ;
+  }
 
   if (!token) {
     return (

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -18,6 +18,7 @@ interface UserStats {
 
 const Home: React.FC = () => {
   const router = useRouter();
+  const [hydrated, setHydrated] = useState(false);
   const [form] = Form.useForm();
   const { clear: clearToken, value: token } = useLocalStorage<string>(
     "token",
@@ -37,6 +38,10 @@ const Home: React.FC = () => {
   });
   const [messageApi, contextHolder] = message.useMessage();
   let response: Response;
+
+    useEffect(() => {
+        setHydrated(true)
+    }, []);
 
   // Create lobby
   const handleStartGame = async () => {
@@ -116,7 +121,6 @@ const Home: React.FC = () => {
         console.error("Error fetching stats:", err);
       }
     };
-
     loadStats();
   }, [token, userId, userIdStr]);
 
@@ -127,7 +131,7 @@ const Home: React.FC = () => {
       if (!response.ok) {
         throw new Error(`Unexpected error: ${response.status}`);
       }
-
+      setHydrated(false);
       clearToken();
       clearUsername();
       clearUserIdStr();
@@ -145,6 +149,10 @@ const Home: React.FC = () => {
       }
     }
   };
+
+  if(!hydrated) {
+      return ;
+  }
 
   if (!token) {
     return (

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -11,6 +11,7 @@ import { message } from "antd";
 
 const JoinGamePage: React.FC = () => {
   const router = useRouter();
+  const [hydrated, setHydrated] = useState(false);
   const { value: userIdStr } = useLocalStorage<string>("userId", "");
   const [digits, setDigits] = useState(["", "", "", ""]);
   const isFull = false;
@@ -38,6 +39,10 @@ const JoinGamePage: React.FC = () => {
       inputsRef.current[index - 1]?.focus();
     }
   };
+
+    useEffect(() => {
+        setHydrated(true)
+    }, []);
 
   // Cleanup: if client exists, deactivate STOMP connection on unmount
   useEffect(() => {
@@ -152,6 +157,10 @@ const JoinGamePage: React.FC = () => {
     color: "#fff",
     padding: "2rem",
   };
+
+    if(!hydrated) {
+        return ;
+    }
 
   if (!token) {
     return (

--- a/app/lobbies/[id]/page.tsx
+++ b/app/lobbies/[id]/page.tsx
@@ -34,6 +34,7 @@ const getUsername = (): string => {
 
 const LobbyPage: React.FC = () => {
   const router = useRouter();
+  const [hydrated, setHydrated] = useState(false);
   const [error] = useState("");
   const { value: token } = useLocalStorage<string>("token", "");
   const username = getUsername();
@@ -44,6 +45,10 @@ const LobbyPage: React.FC = () => {
   const subscriptionRef = useRef<StompSubscription | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [hostLeft, setHostLeft] = useState(false);
+
+    useEffect(() => {
+        setHydrated(true)
+    }, []);
 
   useEffect(() => {
     if (!pin || !token) return;
@@ -165,6 +170,10 @@ const LobbyPage: React.FC = () => {
     const firstId = lobby.usersIds[0];
     return players.find((p) => p.userId === firstId)?.username || "";
   }, [lobby, players]);
+
+    if(!hydrated) {
+        return ;
+    }
 
   if (!token) {
     return (

--- a/app/scoreboard/page.tsx
+++ b/app/scoreboard/page.tsx
@@ -16,6 +16,7 @@ interface UserGetDTO {
 
 export default function ScoreboardPage() {
   const [players, setPlayers] = useState<UserGetDTO[]>([]);
+  const [hydrated, setHydrated] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const rawToken = typeof window !== "undefined"
@@ -27,6 +28,10 @@ export default function ScoreboardPage() {
   const token = rawToken ? rawToken.replace(/^"|"$/g, "") : null;
   const currentUserId = rawUserId ? Number(rawUserId) : null;
   const router = useRouter();
+
+    useEffect(() => {
+        setHydrated(true)
+    }, []);
 
   useEffect(() => {
     const raw = localStorage.getItem("token");
@@ -74,6 +79,10 @@ export default function ScoreboardPage() {
       }
     })();
   }, [token]);
+
+    if(!hydrated) {
+        return ;
+    }
 
   if (!token) {
     return (


### PR DESCRIPTION
- Fix page Unauthorized appearing briefly on page refresh and on logout
- Redirect user who navigate to a non existing to the home page. When a user currently refresh,
when on result view, he lands back on a view of the empty (now deleted) game. This way if he reloads he lands back home instead of being stuck there. The other fixes to notify that the rematch is not possible in this case are implemented in the server.